### PR TITLE
[chore]: update post installation packages

### DIFF
--- a/setup/sys/pkglist/post.pkgs
+++ b/setup/sys/pkglist/post.pkgs
@@ -14,7 +14,6 @@ obs-studio
 obsidian
 ollama-cuda
 onlyoffice-bin
-slack-desktop
 visual-studio-code-bin
 whois
 yt-dlp


### PR DESCRIPTION
removed the slack desktop client.